### PR TITLE
Opencv3 compatibility

### DIFF
--- a/src/rsba/VideoSfMClient.h
+++ b/src/rsba/VideoSfMClient.h
@@ -6,7 +6,18 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/video/tracking.hpp>
+
+#if (defined(CV_VERSION_EPOCH) && CV_VERSION_EPOCH == 2)
+// nothing
+#else
+#define CV_XFEATURES
+#endif
+
+#ifdef CV_XFEATURES
+#include <opencv2/xfeatures2d/nonfree.hpp>
+#else
 #include <opencv2/nonfree/features2d.hpp>
+#endif
 
 #include "rsba/base/pointers.h"
 #include "rsba/VideoSfMHandler.h"
@@ -53,7 +64,11 @@ protected:
   std::string authToken;
   int sessionKey = -1;
 
+#ifdef CV_XFEATURES
+  cv::Ptr<cv::xfeatures2d::SiftFeatureDetector> _siftDetector;
+#else
   cv::SiftFeatureDetector _siftDetector;
+#endif
   cv::BFMatcher l2matcher;
 
   shared_ptr<sfm::gen::VideoSfMIf> handler;

--- a/src/rsba/VideoSfMHandler.cc
+++ b/src/rsba/VideoSfMHandler.cc
@@ -709,7 +709,7 @@ bool VideoSfMHandler::solveRsPnP(const int32_t sessionKey, const SfmOptions& opt
       solvePnPRansac(pts, obs, K, distcoeff,
           rvec, tvec, _opt.mod_init.reuseLastPose, 500,
           sqrt(_opt.tracks.sqrdThreshold)*2,
-          pts.size()*.7, inliers, CV_ITERATIVE);
+          pts.size()*.7, inliers, SOLVEPNP_ITERATIVE);
 
       if (inliers.rows <= 4) {
         solvePnPRansac(pts, obs, K, distcoeff,
@@ -734,7 +734,7 @@ bool VideoSfMHandler::solveRsPnP(const int32_t sessionKey, const SfmOptions& opt
           rvec, tvec, rvec2, tvec2,
           (SHUTTER)sess.rs, sess.scanlines.data(), true, 1000,
           sqrt(_opt.tracks.sqrdThreshold),
-          pts.size()*.7, inliers, cv::ITERATIVE, _opt.mod_init.minPnPfeatures);
+          pts.size()*.7, inliers, SOLVEPNP_ITERATIVE, _opt.mod_init.minPnPfeatures);
       std::cout << rvec << tvec << endl;
       std::cout << rvec2 << tvec2 << endl;
     }

--- a/src/rsba/solveRSpnp.cpp
+++ b/src/rsba/solveRSpnp.cpp
@@ -6,7 +6,13 @@
 
 #include <ceres/rotation.h>
 #include <opencv2/core/core_c.h>
+#if (defined(CV_VERSION_EPOCH) && CV_VERSION_EPOCH == 2)
 #include <opencv2/core/internal.hpp>
+#else
+#define __OPENCV_BUILD
+#include <opencv2/cvconfig.h>
+#include <opencv2/core/private.hpp>
+#endif
 #include <iostream>
 //#include <boost/timer/timer.hpp>
 

--- a/src/rsba/solveRSpnp.h
+++ b/src/rsba/solveRSpnp.h
@@ -5,6 +5,12 @@
 namespace vision
 {
 
+#if (defined(CV_VERSION_EPOCH) && CV_VERSION_EPOCH == 2)
+#define SOLVEPNP_ITERATIVE cv::ITERATIVE
+#else
+#define SOLVEPNP_ITERATIVE cv::SOLVEPNP_ITERATIVE
+#endif
+
 bool solveRsPnP(
     cv::InputArray _opoints,
     cv::InputArray _ipoints,
@@ -17,7 +23,7 @@ bool solveRsPnP(
     const SHUTTER shutter,
     const int scanlines[2],
     bool useExtrinsicGuess = false,
-    int flags = cv::ITERATIVE);
+    int flags = SOLVEPNP_ITERATIVE);
 
 
 void solveRsPnPRansac(
@@ -36,7 +42,7 @@ void solveRsPnPRansac(
     float reprojectionError = 8.0,
     int minInliersCount = 100,
     cv::OutputArray inliers = cv::noArray(),
-    int flags = cv::ITERATIVE,
+    int flags = SOLVEPNP_ITERATIVE,
     int min_points_count = 6);
 
 }


### PR DESCRIPTION
This PR makes rsba compatible with OpenCV3 (tested against v3.1.0), while keeping backwards compatility with OpenCV2. 

There are a couple extra flags that I needed to make it compile in `CMAKE_CXX_FLAGS`: `-I/usr/include/opencv2` because `opencv2/core/private.hpp` needs `"cvconfig.h"`, and `-Wno-error=deprecated` because `-Werror` in the main CMakeLists.txt was blowing up because of theses changes in eigen3 (v3.2.7):

In file included from /usr/include/eigen3/Eigen/Core:276:0,
                 from /usr/include/eigen3/Eigen/Geometry:4,
                 from /home/corollarium/git/rsba/src/rsba/test/mat_test.cc:8:
/usr/include/eigen3/Eigen/src/Core/Functors.h:973:28: warning: 'template<class _Operation> class std::binder2nd' is deprecated [-Wdeprecated-declarations]
 struct functor_traits<std::binder2nd<T> >
                            ^
In file included from /usr/include/c++/5.3.0/bits/stl_function.h:1128:0,
                 from /usr/include/c++/5.3.0/string:48,
                 from /home/corollarium/git/rsba/src/rsba/test/mat_test.cc:5:
/usr/include/c++/5.3.0/backward/binders.h:143:11: note: declared here
     class binder2nd
           ^
In file included from /usr/include/eigen3/Eigen/Core:276:0,
                 from /usr/include/eigen3/Eigen/Geometry:4,
                 from /home/corollarium/git/rsba/src/rsba/test/mat_test.cc:8:
/usr/include/eigen3/Eigen/src/Core/Functors.h:977:28: warning: 'template<class _Operation> class std::binder1st' is deprecated [-Wdeprecated-declarations]
 struct functor_traits<std::binder1st<T> >
                            ^
In file included from /usr/include/c++/5.3.0/bits/stl_function.h:1128:0,
                 from /usr/include/c++/5.3.0/string:48,
                 from /home/corollarium/git/rsba/src/rsba/test/mat_test.cc:5:
/usr/include/c++/5.3.0/backward/binders.h:108:11: note: declared here
     class binder1st
           ^

Perhaps -Werror could be removed from CMakeLists.txt or at least add `-Wno-error=deprecated` to it.